### PR TITLE
CheckInStatusSwitchRequest 필드명 수정

### DIFF
--- a/src/main/kotlin/rainbowfriends/daramserverv2/domain/checkin/dto/request/CheckInStatusSwitchRequest.kt
+++ b/src/main/kotlin/rainbowfriends/daramserverv2/domain/checkin/dto/request/CheckInStatusSwitchRequest.kt
@@ -3,5 +3,5 @@ package rainbowfriends.daramserverv2.domain.checkin.dto.request
 import jakarta.validation.constraints.NotNull
 
 class CheckInStatusSwitchRequest {
-    @field:NotNull val StudentId: Short? = null
+    @field:NotNull val studentId: Short? = null
 }

--- a/src/main/kotlin/rainbowfriends/daramserverv2/domain/checkin/service/impl/CheckInStatusSwitchServiceImpl.kt
+++ b/src/main/kotlin/rainbowfriends/daramserverv2/domain/checkin/service/impl/CheckInStatusSwitchServiceImpl.kt
@@ -12,7 +12,7 @@ class CheckInStatusSwitchServiceImpl(private val checkInStatusSwitch: CheckInSta
     override fun switchCheckInStatus(request: CheckInStatusSwitchRequest) {
         if (!checkInStatusSwitch.switchCheckInStatus(
             date = LocalDate.now(),
-            studentId = request.StudentId
+            studentId = request.studentId
         )){
             throw CheckInStatusSwitchException("CheckIn Status Switch Failed")
         }


### PR DESCRIPTION
refactor: 카멜 표기법을 위반하던 ``CheckInStatusSwitchRequest``의 필드명을 수정